### PR TITLE
Support MCP deep link imports

### DIFF
--- a/MobileCode/CodeAgentsMobileApp.swift
+++ b/MobileCode/CodeAgentsMobileApp.swift
@@ -27,10 +27,16 @@ struct CodeAgentsMobileApp: App {
         }
     }()
 
+    @StateObject private var deepLinkManager = DeepLinkManager.shared
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(deepLinkManager)
         }
         .modelContainer(sharedModelContainer)
+        .onOpenURL { url in
+            deepLinkManager.handle(url: url)
+        }
     }
 }

--- a/MobileCode/Services/DeepLinkManager.swift
+++ b/MobileCode/Services/DeepLinkManager.swift
@@ -1,0 +1,151 @@
+//
+//  DeepLinkManager.swift
+//  CodeAgentsMobile
+//
+//  Created by Code Agent on 2025-02-15.
+//
+
+import Foundation
+
+/// Parse incoming URLs for MCP server or bundle payloads.
+struct DeepLinkParser {
+    private let payloadKeys = ["payload", "data", "config", "json"]
+
+    func parse(url: URL) throws -> DeepLinkPayload {
+        let lowercasedScheme = url.scheme?.lowercased()
+
+        // Supported patterns:
+        // 1. codeagents://mcp/server?payload=...
+        // 2. https://<host>/mcp/server?payload=...
+        // 3. codeagents://add?type=server&payload=...
+
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+        let host = url.host?.lowercased()
+
+        let (category, action): (String?, String?)
+
+        if host == "mcp" {
+            category = "mcp"
+            action = pathComponents.first
+        } else if pathComponents.first?.lowercased() == "mcp" {
+            category = "mcp"
+            action = pathComponents.dropFirst().first
+        } else if host == "add" || pathComponents.first?.lowercased() == "add" {
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let type = components?.queryItems?.first { $0.name.lowercased() == "type" }?.value?.lowercased()
+            category = "mcp"
+            action = type
+        } else if lowercasedScheme == "mcp", let schemeAction = host ?? pathComponents.first {
+            category = "mcp"
+            action = schemeAction.lowercased()
+        } else {
+            throw DeepLinkError("Unsupported deep link: \(url.absoluteString)")
+        }
+
+        guard category == "mcp" else {
+            throw DeepLinkError("Unsupported deep link category")
+        }
+
+        guard let action else {
+            throw DeepLinkError("Deep link is missing an action")
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+
+        guard let payloadValue = queryItems.first(where: { payloadKeys.contains($0.name.lowercased()) })?.value else {
+            throw DeepLinkError("Deep link is missing payload data")
+        }
+
+        guard let data = decodePayload(payloadValue) else {
+            throw DeepLinkError("Unable to decode payload data")
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .useDefaultKeys
+
+        switch action.lowercased() {
+        case "server", "mcp-server", "add-server":
+            let payload = try decoder.decode(DeepLinkServerPayload.self, from: data)
+            return .server(payload)
+        case "bundle", "mcp-bundle", "bundle-install":
+            let payload = try decoder.decode(DeepLinkBundlePayload.self, from: data)
+            return .bundle(payload)
+        default:
+            throw DeepLinkError("Unsupported deep link action: \(action)")
+        }
+    }
+
+    private func decodePayload(_ value: String) -> Data? {
+        // Try direct Base64 decoding first.
+        if let data = Data(base64Encoded: value) {
+            return data
+        }
+
+        // Try URL-safe Base64.
+        var sanitized = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let padding = sanitized.count % 4
+        if padding != 0 {
+            sanitized.append(String(repeating: "=", count: 4 - padding))
+        }
+
+        if let data = Data(base64Encoded: sanitized) {
+            return data
+        }
+
+        // Fall back to treating the payload as raw JSON text.
+        if let jsonData = value.removingPercentEncoding?.data(using: .utf8) {
+            return jsonData
+        }
+
+        return value.data(using: .utf8)
+    }
+}
+
+/// Manages pending deep link requests and surfaces them to SwiftUI views.
+@MainActor
+final class DeepLinkManager: ObservableObject {
+    static let shared = DeepLinkManager()
+
+    struct Request: Identifiable, Equatable {
+        let id = UUID()
+        let sourceURL: URL
+        let payload: DeepLinkPayload
+        let suggestedProjectId: UUID?
+    }
+
+    @Published var pendingRequest: Request?
+    @Published var error: DeepLinkError?
+
+    private let parser = DeepLinkParser()
+
+    private init() {}
+
+    func handle(url: URL) {
+        Task {
+            do {
+                let payload = try parser.parse(url: url)
+                let suggestedProject = ProjectContext.shared.activeProject?.id
+                let request = Request(sourceURL: url, payload: payload, suggestedProjectId: suggestedProject)
+                self.pendingRequest = request
+            } catch let error as DeepLinkError {
+                self.error = error
+            } catch {
+                self.error = DeepLinkError(error.localizedDescription)
+            }
+        }
+    }
+
+    func clear(request: Request) {
+        if pendingRequest?.id == request.id {
+            pendingRequest = nil
+        }
+    }
+
+    func clearError() {
+        error = nil
+    }
+}

--- a/MobileCode/Services/MCPDeepLinkImporter.swift
+++ b/MobileCode/Services/MCPDeepLinkImporter.swift
@@ -1,0 +1,99 @@
+//
+//  MCPDeepLinkImporter.swift
+//  CodeAgentsMobile
+//
+//  Created by Code Agent on 2025-02-15.
+//
+
+import Foundation
+
+protocol MCPServerManaging {
+    func fetchServers(for project: RemoteProject) async throws -> [MCPServer]
+    func addServer(_ server: MCPServer, scope: MCPServer.MCPScope, for project: RemoteProject) async throws
+}
+
+extension MCPService: MCPServerManaging {}
+
+/// Summary of servers added when processing a deep link.
+struct MCPDeepLinkImportSummary: Equatable {
+    struct AddedServer: Equatable {
+        let originalName: String
+        let finalName: String
+        let scope: MCPServer.MCPScope
+    }
+
+    let bundleName: String?
+    let addedServers: [AddedServer]
+
+    var renamedServers: [AddedServer] {
+        addedServers.filter { $0.originalName.caseInsensitiveCompare($0.finalName) != .orderedSame }
+    }
+
+    var count: Int { addedServers.count }
+}
+
+/// Handles importing MCP servers from deep link payloads into a project.
+@MainActor
+struct MCPDeepLinkImporter {
+    private let service: MCPServerManaging
+
+    init(service: MCPServerManaging = MCPService.shared) {
+        self.service = service
+    }
+
+    func importServer(_ payload: DeepLinkServerPayload, into project: RemoteProject) async throws -> MCPDeepLinkImportSummary {
+        let summary = try await importServers([payload], bundleName: nil, into: project)
+        return summary
+    }
+
+    func importBundle(_ payload: DeepLinkBundlePayload, into project: RemoteProject) async throws -> MCPDeepLinkImportSummary {
+        guard !payload.servers.isEmpty else {
+            throw DeepLinkImportError.emptyBundle
+        }
+        return try await importServers(payload.servers, bundleName: payload.name, into: project)
+    }
+
+    private func importServers(_ payloads: [DeepLinkServerPayload], bundleName: String?, into project: RemoteProject) async throws -> MCPDeepLinkImportSummary {
+        let existingServers = try await service.fetchServers(for: project)
+        var usedNames = Set(existingServers.map { $0.name.lowercased() })
+        var added: [MCPDeepLinkImportSummary.AddedServer] = []
+
+        for payload in payloads {
+            let uniqueName = generateUniqueName(for: payload.name, usedNames: &usedNames)
+            let server = try payload.makeServer(named: uniqueName)
+            do {
+                try await service.addServer(server, scope: payload.scope, for: project)
+            } catch {
+                throw DeepLinkImportError.importFailed("Failed to add server \(uniqueName): \(error.localizedDescription)")
+            }
+
+            added.append(.init(originalName: payload.name, finalName: uniqueName, scope: payload.scope))
+        }
+
+        return MCPDeepLinkImportSummary(bundleName: bundleName, addedServers: added)
+    }
+
+    private func generateUniqueName(for baseName: String, usedNames: inout Set<String>) -> String {
+        let trimmed = baseName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = trimmed.lowercased()
+
+        guard !trimmed.isEmpty else {
+            return UUID().uuidString
+        }
+
+        if !usedNames.contains(normalized) {
+            usedNames.insert(normalized)
+            return trimmed
+        }
+
+        var index = 2
+        while true {
+            let candidate = "\(trimmed)-\(index)"
+            if !usedNames.contains(candidate.lowercased()) {
+                usedNames.insert(candidate.lowercased())
+                return candidate
+            }
+            index += 1
+        }
+    }
+}

--- a/MobileCode/Services/MCPDeepLinkModels.swift
+++ b/MobileCode/Services/MCPDeepLinkModels.swift
@@ -1,0 +1,279 @@
+//
+//  MCPDeepLinkModels.swift
+//  CodeAgentsMobile
+//
+//  Created by Code Agent on 2025-02-15.
+//
+
+import Foundation
+
+/// Payload for a single MCP server shared via deep link.
+/// Supports both flat definitions and nested `config` blocks similar to `.mcp.json` files.
+struct DeepLinkServerPayload: Codable, Equatable {
+    let name: String
+    let type: String?
+    let command: String?
+    let args: [String]?
+    let env: [String: String]?
+    let url: String?
+    let headers: [String: String]?
+    private let scopeRaw: String?
+
+    /// Optional user-facing description included in some payload formats.
+    let summary: String?
+
+    init(
+        name: String,
+        type: String? = nil,
+        command: String? = nil,
+        args: [String]? = nil,
+        env: [String: String]? = nil,
+        url: String? = nil,
+        headers: [String: String]? = nil,
+        scope: MCPServer.MCPScope = .project,
+        summary: String? = nil
+    ) {
+        self.name = name
+        self.type = type
+        self.command = command
+        self.args = args
+        self.env = env
+        self.url = url
+        self.headers = headers
+        self.scopeRaw = scope.rawValue
+        self.summary = summary
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case serverName
+        case type
+        case command
+        case args
+        case env
+        case environment
+        case url
+        case headers
+        case scope
+        case config
+        case summary
+        case description
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let directName = try container.decodeIfPresent(String.self, forKey: .name) {
+            name = directName
+        } else if let altName = try container.decodeIfPresent(String.self, forKey: .serverName) {
+            name = altName
+        } else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.name,
+                DecodingError.Context(codingPath: container.codingPath, debugDescription: "Server name missing in deep link payload")
+            )
+        }
+
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+        summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? container.decodeIfPresent(String.self, forKey: .description)
+
+        // Decode scope if present
+        scopeRaw = try container.decodeIfPresent(String.self, forKey: .scope)
+
+        // Helper to decode command-related fields either at top level or inside a `config` object.
+        func decodeCommand(from container: KeyedDecodingContainer<CodingKeys>) throws -> (String?, [String]?, [String: String]?, String?, [String: String]?) {
+            let command = try container.decodeIfPresent(String.self, forKey: .command)
+
+            // Args may be encoded either as array of strings or a single string.
+            var args: [String]? = try container.decodeIfPresent([String].self, forKey: .args)
+            if args == nil, let argsString = try container.decodeIfPresent(String.self, forKey: .args) {
+                args = argsString.split(separator: " ").map { String($0) }
+            }
+
+            let env = try container.decodeIfPresent([String: String].self, forKey: .env)
+                ?? container.decodeIfPresent([String: String].self, forKey: .environment)
+            let url = try container.decodeIfPresent(String.self, forKey: .url)
+            let headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
+
+            return (command, args, env, url, headers)
+        }
+
+        if container.contains(.config) {
+            let nested = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .config)
+            let values = try decodeCommand(from: nested)
+            command = values.0
+            args = values.1
+            env = values.2
+            url = values.3
+            headers = values.4
+        } else {
+            let values = try decodeCommand(from: container)
+            command = values.0
+            args = values.1
+            env = values.2
+            url = values.3
+            headers = values.4
+        }
+    }
+
+    /// Preferred scope requested by the payload (defaults to project scope).
+    var scope: MCPServer.MCPScope {
+        guard let scopeRaw else { return .project }
+        return MCPServer.MCPScope(rawValue: scopeRaw.lowercased()) ?? .project
+    }
+
+    /// Determine whether this payload represents a remote server.
+    var isRemote: Bool {
+        if let url = url, !url.isEmpty { return true }
+        guard let type else { return false }
+        let lowered = type.lowercased()
+        return lowered == "http" || lowered == "sse"
+    }
+
+    /// Create an `MCPServer` from the payload, optionally overriding the name.
+    func makeServer(named overrideName: String? = nil) throws -> MCPServer {
+        let trimmedName = (overrideName ?? name).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw DeepLinkImportError.invalidServer("Server name cannot be empty")
+        }
+
+        if isRemote {
+            guard let url = url, !url.isEmpty else {
+                throw DeepLinkImportError.invalidServer("Remote MCP server \(name) is missing a URL")
+            }
+
+            return MCPServer(
+                name: trimmedName,
+                command: nil,
+                args: nil,
+                env: nil,
+                url: url,
+                headers: headers
+            )
+        }
+
+        guard let command = command, !command.isEmpty else {
+            throw DeepLinkImportError.invalidServer("Local MCP server \(name) is missing a command")
+        }
+
+        return MCPServer(
+            name: trimmedName,
+            command: command,
+            args: args,
+            env: env,
+            url: nil,
+            headers: nil
+        )
+    }
+}
+
+/// Payload describing a bundle of MCP servers shared via deep link.
+struct DeepLinkBundlePayload: Codable, Equatable {
+    let name: String
+    let description: String?
+    let servers: [DeepLinkServerPayload]
+
+    init(name: String, description: String? = nil, servers: [DeepLinkServerPayload]) {
+        self.name = name
+        self.description = description
+        self.servers = servers
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case bundleName
+        case description
+        case summary
+        case servers
+        case mcpServers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let directName = try container.decodeIfPresent(String.self, forKey: .name) {
+            name = directName
+        } else if let bundleName = try container.decodeIfPresent(String.self, forKey: .bundleName) {
+            name = bundleName
+        } else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.name,
+                DecodingError.Context(codingPath: container.codingPath, debugDescription: "Bundle name missing in deep link payload")
+            )
+        }
+
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+            ?? container.decodeIfPresent(String.self, forKey: .summary)
+
+        if let array = try container.decodeIfPresent([DeepLinkServerPayload].self, forKey: .servers) {
+            servers = array
+        } else if let dict = try container.decodeIfPresent([String: MCPServer.Configuration].self, forKey: .servers) {
+            servers = dict.map { key, value in
+                DeepLinkServerPayload(
+                    name: key,
+                    command: value.command,
+                    args: value.args,
+                    env: value.env,
+                    url: value.url,
+                    headers: value.headers
+                )
+            }
+        } else if let dict = try container.decodeIfPresent([String: MCPServer.Configuration].self, forKey: .mcpServers) {
+            servers = dict.map { key, value in
+                DeepLinkServerPayload(
+                    name: key,
+                    command: value.command,
+                    args: value.args,
+                    env: value.env,
+                    url: value.url,
+                    headers: value.headers
+                )
+            }
+        } else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.servers,
+                DecodingError.Context(codingPath: container.codingPath, debugDescription: "Bundle payload does not contain any servers")
+            )
+        }
+    }
+}
+
+/// Combined payload produced by decoding an incoming deep link.
+enum DeepLinkPayload: Equatable {
+    case server(DeepLinkServerPayload)
+    case bundle(DeepLinkBundlePayload)
+}
+
+/// General error produced while parsing a deep link URL.
+struct DeepLinkError: LocalizedError, Identifiable, Equatable {
+    let id = UUID()
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? { message }
+
+    static func == (lhs: DeepLinkError, rhs: DeepLinkError) -> Bool {
+        lhs.message == rhs.message
+    }
+}
+
+/// Errors thrown while importing servers from a deep link payload.
+enum DeepLinkImportError: LocalizedError {
+    case invalidServer(String)
+    case emptyBundle
+    case importFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidServer(let message):
+            return message
+        case .emptyBundle:
+            return "The bundle does not contain any MCP servers."
+        case .importFailed(let message):
+            return message
+        }
+    }
+}

--- a/MobileCode/Services/MCPDeepLinkModels.swift
+++ b/MobileCode/Services/MCPDeepLinkModels.swift
@@ -142,13 +142,23 @@ struct DeepLinkServerPayload: Codable, Equatable {
                 throw DeepLinkImportError.invalidServer("Remote MCP server \(name) is missing a URL")
             }
 
+            let resolvedType: String
+            if let providedType = type?.trimmingCharacters(in: .whitespacesAndNewlines), !providedType.isEmpty {
+                resolvedType = providedType.lowercased()
+            } else if url.lowercased().contains("sse") {
+                resolvedType = "sse"
+            } else {
+                resolvedType = "http"
+            }
+
             return MCPServer(
                 name: trimmedName,
                 command: nil,
                 args: nil,
                 env: nil,
                 url: url,
-                headers: headers
+                headers: headers,
+                type: resolvedType
             )
         }
 
@@ -156,13 +166,16 @@ struct DeepLinkServerPayload: Codable, Equatable {
             throw DeepLinkImportError.invalidServer("Local MCP server \(name) is missing a command")
         }
 
+        let resolvedType = type?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
         return MCPServer(
             name: trimmedName,
             command: command,
             args: args,
             env: env,
             url: nil,
-            headers: nil
+            headers: nil,
+            type: (resolvedType?.isEmpty == false ? resolvedType : "stdio")
         )
     }
 }

--- a/MobileCode/Services/MCPStatusParser.swift
+++ b/MobileCode/Services/MCPStatusParser.swift
@@ -254,7 +254,8 @@ struct MCPStatusParser {
                 args: args.isEmpty ? nil : args,
                 env: env.isEmpty ? nil : env,
                 url: nil,
-                headers: nil
+                headers: nil,
+                type: type
             )
         } else {
             // Remote server (sse or http)
@@ -264,7 +265,8 @@ struct MCPStatusParser {
                 args: nil,
                 env: nil,
                 url: url,
-                headers: headers.isEmpty ? nil : headers
+                headers: headers.isEmpty ? nil : headers,
+                type: type
             )
         }
         

--- a/MobileCode/Views/ContentView.swift
+++ b/MobileCode/Views/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @StateObject private var projectContext = ProjectContext.shared
     @StateObject private var serverManager = ServerManager.shared
     @StateObject private var cloudInitMonitor = CloudInitMonitor.shared
+    @EnvironmentObject private var deepLinkManager: DeepLinkManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
     
@@ -68,8 +69,23 @@ struct ContentView: View {
                 break
             }
         }
+        .sheet(item: $deepLinkManager.pendingRequest) { request in
+            MCPDeepLinkImportSheet(request: request)
+        }
+        .alert("Unable to Open Link", isPresented: Binding(
+            get: { deepLinkManager.error != nil },
+            set: { newValue in
+                if !newValue {
+                    deepLinkManager.clearError()
+                }
+            }
+        ), actions: {
+            Button("OK", role: .cancel) {}
+        }, message: {
+            Text(deepLinkManager.error?.message ?? "An unknown error occurred.")
+        })
     }
-    
+
     private func configureManagers() {
         // Load servers for ServerManager
         serverManager.loadServers(from: modelContext)

--- a/MobileCode/Views/MCP/MCPDeepLinkImportSheet.swift
+++ b/MobileCode/Views/MCP/MCPDeepLinkImportSheet.swift
@@ -1,0 +1,262 @@
+//
+//  MCPDeepLinkImportSheet.swift
+//  CodeAgentsMobile
+//
+//  Created by Code Agent on 2025-02-15.
+//
+
+import SwiftUI
+import SwiftData
+
+struct MCPDeepLinkImportSheet: View {
+    let request: DeepLinkManager.Request
+
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(sort: \RemoteProject.name) private var projects: [RemoteProject]
+
+    @State private var selectedProjectId: UUID?
+    @State private var isImporting = false
+    @State private var errorMessage: String?
+    @State private var showError = false
+    @State private var importSummary: MCPDeepLinkImportSummary?
+
+    private let importer = MCPDeepLinkImporter()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                projectSection
+
+                detailsSection
+
+                Section(footer: footerText) {
+                    EmptyView()
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isImporting)
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: importPayload) {
+                        if isImporting {
+                            ProgressView()
+                        } else {
+                            Text(actionButtonTitle)
+                        }
+                    }
+                    .disabled(!canImport)
+                }
+            }
+            .alert("Error", isPresented: $showError, actions: {
+                Button("OK", role: .cancel) { }
+            }, message: {
+                Text(errorMessage ?? "An error occurred")
+            })
+            .onAppear(perform: prepareSelection)
+            .onDisappear { DeepLinkManager.shared.clear(request: request) }
+        }
+        .interactiveDismissDisabled(isImporting)
+    }
+
+    private var projectSection: some View {
+        Section("Project") {
+            if projects.isEmpty {
+                Text("No projects available. Create a project first in the Projects tab.")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+            } else {
+                Picker("Add to", selection: Binding(
+                    get: { selectedProjectId },
+                    set: { selectedProjectId = $0 }
+                )) {
+                    ForEach(projects) { project in
+                        Text(project.name)
+                            .tag(project.id as UUID?)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        switch request.payload {
+        case .server(let server):
+            Section("Server") {
+                LabeledContent("Name") { Text(server.name) }
+
+                if server.isRemote {
+                    if let url = server.url {
+                        LabeledContent("URL") { Text(url).textSelection(.enabled) }
+                    }
+                    if let headers = server.headers, !headers.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Headers")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            ForEach(headers.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                                HStack {
+                                    Text(key)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Text(value)
+                                        .font(.caption)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    if let command = server.command {
+                        LabeledContent("Command") {
+                            Text(command)
+                                .font(.system(.body, design: .monospaced))
+                        }
+                    }
+                    if let args = server.args, !args.isEmpty {
+                        LabeledContent("Arguments") {
+                            Text(args.joined(separator: " "))
+                                .font(.system(.caption, design: .monospaced))
+                        }
+                    }
+                    if let env = server.env, !env.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Environment")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            ForEach(env.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                                HStack {
+                                    Text(key)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Text(value)
+                                        .font(.caption)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                LabeledContent("Scope") {
+                    Text(server.scope.displayName)
+                        .foregroundColor(.secondary)
+                }
+
+                if let summary = server.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case .bundle(let bundle):
+            Section("Bundle") {
+                LabeledContent("Name") { Text(bundle.name) }
+                if let description = bundle.description, !description.isEmpty {
+                    Text(description)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                }
+                LabeledContent("Servers") {
+                    Text("\(bundle.servers.count)")
+                        .foregroundColor(.secondary)
+                }
+
+                ForEach(Array(bundle.servers.enumerated()), id: \.offset) { _, server in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(server.name)
+                            .font(.subheadline)
+                        Text(server.isRemote ? "Remote" : "Local")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    private var footerText: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Existing MCP servers with the same name will be renamed automatically.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            if let summary = importSummary {
+                let renamed = summary.renamedServers
+                if !renamed.isEmpty {
+                    Text("Renamed: \(renamed.map { "\($0.originalName) → \($0.finalName)" }.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    private var title: String {
+        switch request.payload {
+        case .server:
+            return "Add MCP Server"
+        case .bundle:
+            return "Install MCP Bundle"
+        }
+    }
+
+    private var actionButtonTitle: String {
+        switch request.payload {
+        case .server:
+            return "Add"
+        case .bundle:
+            return "Install"
+        }
+    }
+
+    private var canImport: Bool {
+        !isImporting && selectedProjectId != nil && !projects.isEmpty
+    }
+
+    private func prepareSelection() {
+        if let suggested = request.suggestedProjectId, projects.contains(where: { $0.id == suggested }) {
+            selectedProjectId = suggested
+        } else if selectedProjectId == nil {
+            selectedProjectId = projects.first?.id
+        }
+    }
+
+    private func importPayload() {
+        guard let projectId = selectedProjectId, let project = projects.first(where: { $0.id == projectId }) else {
+            return
+        }
+
+        isImporting = true
+        errorMessage = nil
+
+        Task {
+            do {
+                switch request.payload {
+                case .server(let server):
+                    importSummary = try await importer.importServer(server, into: project)
+                case .bundle(let bundle):
+                    importSummary = try await importer.importBundle(bundle, into: project)
+                }
+
+                NotificationCenter.default.post(name: .mcpConfigurationChanged, object: nil)
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
+
+            isImporting = false
+        }
+    }
+}

--- a/MobileCodeTests/MCPDeepLinkTests.swift
+++ b/MobileCodeTests/MCPDeepLinkTests.swift
@@ -1,0 +1,144 @@
+//
+//  MCPDeepLinkTests.swift
+//  MobileCodeTests
+//
+//  Created by Code Agent on 2025-02-15.
+//
+
+import Testing
+@testable import CodeAgentsMobile
+import Foundation
+
+@MainActor
+struct MCPDeepLinkTests {
+    private let parser = DeepLinkParser()
+
+    @Test func parseServerDeepLink() throws {
+        let serverJSON = """
+        {
+            "name": "firecrawl",
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "firecrawl-mcp"],
+            "env": {
+                "FIRECRAWL_API_KEY": "test"
+            },
+            "scope": "project"
+        }
+        """
+
+        let encoded = serverJSON.data(using: .utf8)!.base64EncodedString()
+        let url = URL(string: "codeagents://mcp/server?payload=\(encoded)")!
+
+        let payload = try parser.parse(url: url)
+
+        switch payload {
+        case .server(let server):
+            #expect(server.name == "firecrawl")
+            #expect(server.command == "npx")
+            #expect(server.args == ["-y", "firecrawl-mcp"])
+            #expect(server.env?["FIRECRAWL_API_KEY"] == "test")
+            #expect(server.scope == .project)
+        default:
+            Issue.record("Expected server payload")
+        }
+    }
+
+    @Test func parseBundleDeepLink() throws {
+        let bundleJSON = """
+        {
+            "bundleName": "Starter",
+            "servers": {
+                "search": {
+                    "type": "http",
+                    "url": "https://example.com/mcp"
+                },
+                "playwright": {
+                    "command": "npx",
+                    "args": ["@playwright/mcp@latest"]
+                }
+            }
+        }
+        """
+
+        let encoded = bundleJSON.data(using: .utf8)!.base64EncodedString()
+        let url = URL(string: "https://example.com/mcp/bundle?payload=\(encoded)")!
+
+        let payload = try parser.parse(url: url)
+
+        switch payload {
+        case .bundle(let bundle):
+            #expect(bundle.name == "Starter")
+            #expect(bundle.servers.count == 2)
+            #expect(bundle.servers.contains(where: { $0.name == "search" && $0.url == "https://example.com/mcp" }))
+            #expect(bundle.servers.contains(where: { $0.name == "playwright" && $0.command == "npx" }))
+        default:
+            Issue.record("Expected bundle payload")
+        }
+    }
+
+    @Test func importerRenamesDuplicateServers() async throws {
+        let project = RemoteProject(name: "Demo", serverId: UUID())
+        let existing = [
+            MCPServer(name: "firecrawl", command: "npx", args: ["-y", "firecrawl-mcp"], env: nil, url: nil, headers: nil)
+        ]
+        let mockService = MockMCPService(existing: existing)
+        let importer = MCPDeepLinkImporter(service: mockService)
+
+        let payload = DeepLinkServerPayload(
+            name: "firecrawl",
+            command: "uv",
+            args: ["run", "server"],
+            env: nil,
+            url: nil,
+            headers: nil,
+            scope: .project
+        )
+
+        let summary = try await importer.importServer(payload, into: project)
+
+        #expect(summary.addedServers.count == 1)
+        #expect(summary.addedServers.first?.finalName == "firecrawl-2")
+        #expect(mockService.addedServers.first?.server.name == "firecrawl-2")
+    }
+
+    @Test func importerHandlesBundles() async throws {
+        let project = RemoteProject(name: "Bundle", serverId: UUID())
+        let mockService = MockMCPService(existing: [])
+        let importer = MCPDeepLinkImporter(service: mockService)
+
+        let bundle = DeepLinkBundlePayload(
+            name: "Utilities",
+            servers: [
+                DeepLinkServerPayload(name: "search", url: "https://example.com/mcp", headers: nil, scope: .project),
+                DeepLinkServerPayload(name: "search", command: "npx", args: ["-y", "firecrawl"], env: nil, headers: nil, scope: .project)
+            ]
+        )
+
+        let summary = try await importer.importBundle(bundle, into: project)
+
+        #expect(summary.addedServers.count == 2)
+        let finalNames = summary.addedServers.map { $0.finalName }
+        #expect(finalNames.contains("search"))
+        #expect(finalNames.contains("search-2"))
+    }
+}
+
+@MainActor
+private final class MockMCPService: MCPServerManaging {
+    var existingServers: [MCPServer]
+    var addedServers: [(server: MCPServer, scope: MCPServer.MCPScope, project: RemoteProject)] = []
+
+    init(existing: [MCPServer]) {
+        self.existingServers = existing
+    }
+
+    func fetchServers(for project: RemoteProject) async throws -> [MCPServer] {
+        existingServers
+    }
+
+    func addServer(_ server: MCPServer, scope: MCPServer.MCPScope, for project: RemoteProject) async throws {
+        addedServers.append((server: server, scope: scope, project: project))
+        existingServers.append(server)
+    }
+}


### PR DESCRIPTION
## Summary
- add a deep link parser and manager so incoming MCP server or bundle links can be handled inside the app
- present an import sheet that lets the user pick a project, reviews the server or bundle details, and prevents duplicate names
- add importer utilities plus unit tests covering deep link parsing and unique-name handling

## Testing
- swift test *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68f48d5b694483218222055dfa4cfaa0